### PR TITLE
Add waste collection schedule app for Cure Afvalbeheer

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,154 @@
+"""Waste collection schedule app for Cure Afvalbeheer (Eindhoven, Geldrop-Mierlo, Valkenswaard).
+
+Fetches waste collection dates from the MijnAfvalwijzer API and displays them
+in a user-friendly web interface.
+"""
+
+import re
+from datetime import datetime
+
+import requests
+from flask import Flask, render_template, request, jsonify
+
+app = Flask(__name__)
+
+API_URL = (
+    "https://api.mijnafvalwijzer.nl/webservices/appsinput/"
+    "?apikey=5ef443e778f41c4f75c69459eea6e6ae0c2d92de729aa0fc61653815fbd6a8ca"
+    "&method=postcodecheck&postcode={postcode}&street="
+    "&huisnummer={huisnummer}&toevoeging={toevoeging}"
+    "&app_name=afvalwijzer&platform=web&langs=nl"
+    "&afvaldata={startdate}"
+)
+
+WASTE_TYPE_ICONS = {
+    "gft": {"label": "GFT", "icon": "🌿", "color": "#4CAF50"},
+    "restafval": {"label": "Restafval", "icon": "🗑️", "color": "#757575"},
+    "papier": {"label": "Papier", "icon": "📦", "color": "#2196F3"},
+    "pmd": {"label": "PMD", "icon": "♻️", "color": "#FF9800"},
+    "plastic": {"label": "Plastic", "icon": "♻️", "color": "#FF9800"},
+    "textiel": {"label": "Textiel", "icon": "👕", "color": "#9C27B0"},
+    "kerstbomen": {"label": "Kerstbomen", "icon": "🎄", "color": "#2E7D32"},
+    "grof": {"label": "Grof afval", "icon": "🪑", "color": "#795548"},
+}
+
+DEFAULT_WASTE_INFO = {"label": "", "icon": "🗑️", "color": "#607D8B"}
+
+
+def validate_postcode(postcode):
+    """Validate Dutch postal code format (4 digits + 2 letters)."""
+    cleaned = postcode.strip().replace(" ", "").upper()
+    if re.match(r"^\d{4}[A-Z]{2}$", cleaned):
+        return cleaned
+    return None
+
+
+def validate_huisnummer(huisnummer):
+    """Validate house number (positive integer)."""
+    cleaned = huisnummer.strip()
+    if cleaned.isdigit() and int(cleaned) > 0:
+        return cleaned
+    return None
+
+
+def fetch_waste_data(postcode, huisnummer, toevoeging=""):
+    """Fetch waste collection data from MijnAfvalwijzer API."""
+    today = datetime.now()
+    start_date = f"{today.year}-01-01"
+
+    url = API_URL.format(
+        postcode=postcode,
+        huisnummer=huisnummer,
+        toevoeging=toevoeging,
+        startdate=start_date,
+    )
+
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+
+    # Parse upcoming collection dates
+    upcoming = []
+    ophaaldagen = data.get("ophaaldagen", {}).get("data", [])
+    ophaaldagen_next = data.get("ophaaldagenNext", {}).get("data", [])
+
+    all_items = ophaaldagen + ophaaldagen_next
+
+    for item in all_items:
+        date_str = item.get("date", "")
+        waste_type = item.get("type", "").lower().strip()
+        if not date_str or not waste_type:
+            continue
+
+        try:
+            date_obj = datetime.strptime(date_str, "%Y-%m-%d")
+        except ValueError:
+            continue
+
+        if date_obj.date() < today.date():
+            continue
+
+        info = WASTE_TYPE_ICONS.get(waste_type, DEFAULT_WASTE_INFO)
+        label = info["label"] or waste_type.capitalize()
+
+        upcoming.append({
+            "date": date_obj.strftime("%Y-%m-%d"),
+            "date_display": date_obj.strftime("%A %d %B %Y"),
+            "type": waste_type,
+            "label": label,
+            "icon": info["icon"],
+            "color": info["color"],
+            "days_until": (date_obj.date() - today.date()).days,
+        })
+
+    # Remove duplicates and sort
+    seen = set()
+    unique = []
+    for item in upcoming:
+        key = (item["date"], item["type"])
+        if key not in seen:
+            seen.add(key)
+            unique.append(item)
+
+    unique.sort(key=lambda x: (x["date"], x["type"]))
+    return unique
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/api/ophaaldata", methods=["GET"])
+def get_ophaaldata():
+    postcode = request.args.get("postcode", "")
+    huisnummer = request.args.get("huisnummer", "")
+    toevoeging = request.args.get("toevoeging", "")
+
+    validated_postcode = validate_postcode(postcode)
+    if not validated_postcode:
+        return jsonify({"error": "Ongeldige postcode. Gebruik formaat: 1234AB"}), 400
+
+    validated_huisnummer = validate_huisnummer(huisnummer)
+    if not validated_huisnummer:
+        return jsonify({"error": "Ongeldig huisnummer."}), 400
+
+    try:
+        data = fetch_waste_data(validated_postcode, validated_huisnummer, toevoeging)
+    except requests.exceptions.RequestException:
+        return jsonify({"error": "Kon geen verbinding maken met de afvalkalender service."}), 502
+    except (ValueError, KeyError):
+        return jsonify({"error": "Onverwacht antwoord van de service."}), 502
+
+    if not data:
+        return jsonify({
+            "error": "Geen ophaaldata gevonden voor dit adres. "
+                     "Controleer of de postcode in het gebied van Cure valt "
+                     "(Eindhoven, Geldrop-Mierlo, Valkenswaard)."
+        }), 404
+
+    return jsonify({"data": data})
+
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pygame
+flask
+requests

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Afvalkalender - Cure Afvalbeheer</title>
+    <style>
+        :root {
+            --primary: #1B5E20;
+            --primary-light: #4CAF50;
+            --bg: #f5f7f5;
+            --card-bg: #ffffff;
+            --text: #212121;
+            --text-light: #757575;
+            --border: #e0e0e0;
+            --error: #c62828;
+            --shadow: 0 2px 8px rgba(0,0,0,0.1);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+        }
+
+        header {
+            background: linear-gradient(135deg, var(--primary) 0%, var(--primary-light) 100%);
+            color: white;
+            padding: 2rem 1rem;
+            text-align: center;
+        }
+
+        header h1 {
+            font-size: 1.8rem;
+            margin-bottom: 0.3rem;
+        }
+
+        header p {
+            opacity: 0.9;
+            font-size: 0.95rem;
+        }
+
+        .container {
+            max-width: 700px;
+            margin: 0 auto;
+            padding: 1.5rem 1rem;
+        }
+
+        .search-card {
+            background: var(--card-bg);
+            border-radius: 12px;
+            padding: 1.5rem;
+            box-shadow: var(--shadow);
+            margin-bottom: 1.5rem;
+        }
+
+        .form-row {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            min-width: 120px;
+        }
+
+        .form-group label {
+            font-size: 0.85rem;
+            font-weight: 600;
+            margin-bottom: 0.3rem;
+            color: var(--text-light);
+        }
+
+        .form-group input {
+            padding: 0.7rem 0.9rem;
+            border: 2px solid var(--border);
+            border-radius: 8px;
+            font-size: 1rem;
+            transition: border-color 0.2s;
+            outline: none;
+        }
+
+        .form-group input:focus {
+            border-color: var(--primary-light);
+        }
+
+        .form-group.postcode { flex: 2; }
+        .form-group.huisnummer { flex: 1.5; }
+        .form-group.toevoeging { flex: 1; }
+
+        .btn-search {
+            width: 100%;
+            margin-top: 1rem;
+            padding: 0.8rem;
+            background: var(--primary);
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.2s;
+        }
+
+        .btn-search:hover {
+            background: var(--primary-light);
+        }
+
+        .btn-search:disabled {
+            background: var(--text-light);
+            cursor: not-allowed;
+        }
+
+        .error-msg {
+            background: #ffebee;
+            color: var(--error);
+            padding: 0.8rem 1rem;
+            border-radius: 8px;
+            margin-bottom: 1rem;
+            font-size: 0.9rem;
+            display: none;
+        }
+
+        .loading {
+            text-align: center;
+            padding: 2rem;
+            color: var(--text-light);
+            display: none;
+        }
+
+        .loading .spinner {
+            display: inline-block;
+            width: 32px;
+            height: 32px;
+            border: 3px solid var(--border);
+            border-top: 3px solid var(--primary-light);
+            border-radius: 50%;
+            animation: spin 0.8s linear infinite;
+            margin-bottom: 0.5rem;
+        }
+
+        @keyframes spin {
+            to { transform: rotate(360deg); }
+        }
+
+        .results {
+            display: none;
+        }
+
+        .results-header {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 1rem;
+            color: var(--text);
+        }
+
+        .date-group {
+            margin-bottom: 1rem;
+        }
+
+        .date-label {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--text-light);
+            margin-bottom: 0.4rem;
+            padding-left: 0.2rem;
+        }
+
+        .waste-item {
+            background: var(--card-bg);
+            border-radius: 10px;
+            padding: 1rem 1.2rem;
+            margin-bottom: 0.5rem;
+            box-shadow: var(--shadow);
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+            border-left: 4px solid var(--primary-light);
+            transition: transform 0.15s;
+        }
+
+        .waste-item:hover {
+            transform: translateX(4px);
+        }
+
+        .waste-icon {
+            font-size: 1.8rem;
+            flex-shrink: 0;
+        }
+
+        .waste-info {
+            flex: 1;
+        }
+
+        .waste-type {
+            font-weight: 600;
+            font-size: 1rem;
+        }
+
+        .waste-date {
+            font-size: 0.85rem;
+            color: var(--text-light);
+        }
+
+        .waste-badge {
+            font-size: 0.75rem;
+            padding: 0.2rem 0.6rem;
+            border-radius: 12px;
+            font-weight: 600;
+            color: white;
+            flex-shrink: 0;
+        }
+
+        .today-badge {
+            background: #c62828;
+        }
+
+        .tomorrow-badge {
+            background: #EF6C00;
+        }
+
+        .this-week-badge {
+            background: #1565C0;
+        }
+
+        footer {
+            text-align: center;
+            padding: 1.5rem;
+            color: var(--text-light);
+            font-size: 0.8rem;
+        }
+
+        footer a {
+            color: var(--primary);
+            text-decoration: none;
+        }
+
+        @media (max-width: 480px) {
+            header h1 { font-size: 1.4rem; }
+            .form-row { flex-direction: column; gap: 0.5rem; }
+            .form-group { min-width: 100%; }
+        }
+    </style>
+</head>
+<body>
+
+<header>
+    <h1>Afvalkalender</h1>
+    <p>Cure Afvalbeheer &mdash; Eindhoven, Geldrop-Mierlo, Valkenswaard</p>
+</header>
+
+<div class="container">
+    <div class="search-card">
+        <form id="searchForm">
+            <div class="form-row">
+                <div class="form-group postcode">
+                    <label for="postcode">Postcode</label>
+                    <input type="text" id="postcode" name="postcode" placeholder="bijv. 5611AA" maxlength="7" required>
+                </div>
+                <div class="form-group huisnummer">
+                    <label for="huisnummer">Huisnummer</label>
+                    <input type="text" id="huisnummer" name="huisnummer" placeholder="bijv. 1" maxlength="6" required>
+                </div>
+                <div class="form-group toevoeging">
+                    <label for="toevoeging">Toev.</label>
+                    <input type="text" id="toevoeging" name="toevoeging" placeholder="bijv. A" maxlength="10">
+                </div>
+            </div>
+            <button type="submit" class="btn-search" id="btnSearch">Zoek ophaaldata</button>
+        </form>
+    </div>
+
+    <div class="error-msg" id="errorMsg"></div>
+    <div class="loading" id="loading">
+        <div class="spinner"></div>
+        <div>Ophaaldata laden...</div>
+    </div>
+
+    <div class="results" id="results">
+        <div class="results-header" id="resultsHeader"></div>
+        <div id="resultsList"></div>
+    </div>
+</div>
+
+<footer>
+    Data via <a href="https://www.mijnafvalwijzer.nl" target="_blank" rel="noopener">MijnAfvalwijzer</a>
+    &bull; <a href="https://www.cure-afvalbeheer.nl" target="_blank" rel="noopener">Cure Afvalbeheer</a>
+</footer>
+
+<script>
+const DUTCH_DAYS = ['zondag','maandag','dinsdag','woensdag','donderdag','vrijdag','zaterdag'];
+const DUTCH_MONTHS = ['januari','februari','maart','april','mei','juni','juli','augustus','september','oktober','november','december'];
+
+function formatDate(dateStr) {
+    const d = new Date(dateStr + 'T00:00:00');
+    return `${DUTCH_DAYS[d.getDay()]} ${d.getDate()} ${DUTCH_MONTHS[d.getMonth()]} ${d.getFullYear()}`;
+}
+
+function getBadge(daysUntil) {
+    if (daysUntil === 0) return '<span class="waste-badge today-badge">Vandaag</span>';
+    if (daysUntil === 1) return '<span class="waste-badge tomorrow-badge">Morgen</span>';
+    if (daysUntil <= 7) return '<span class="waste-badge this-week-badge">Deze week</span>';
+    return '';
+}
+
+document.getElementById('searchForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+
+    const postcode = document.getElementById('postcode').value.trim();
+    const huisnummer = document.getElementById('huisnummer').value.trim();
+    const toevoeging = document.getElementById('toevoeging').value.trim();
+
+    const errorEl = document.getElementById('errorMsg');
+    const loadingEl = document.getElementById('loading');
+    const resultsEl = document.getElementById('results');
+    const btn = document.getElementById('btnSearch');
+
+    errorEl.style.display = 'none';
+    resultsEl.style.display = 'none';
+    loadingEl.style.display = 'block';
+    btn.disabled = true;
+
+    try {
+        const params = new URLSearchParams({postcode, huisnummer, toevoeging});
+        const resp = await fetch(`/api/ophaaldata?${params}`);
+        const json = await resp.json();
+
+        if (!resp.ok) {
+            throw new Error(json.error || 'Er ging iets mis.');
+        }
+
+        const items = json.data;
+        if (!items || items.length === 0) {
+            throw new Error('Geen ophaaldata gevonden.');
+        }
+
+        // Group by date
+        const grouped = {};
+        items.forEach(item => {
+            if (!grouped[item.date]) grouped[item.date] = [];
+            grouped[item.date].push(item);
+        });
+
+        let html = '';
+        const dates = Object.keys(grouped).sort();
+
+        // Show max 30 upcoming dates
+        const shownDates = dates.slice(0, 30);
+
+        shownDates.forEach(date => {
+            const dateDisplay = formatDate(date);
+            html += `<div class="date-group"><div class="date-label">${dateDisplay}</div>`;
+
+            grouped[date].forEach(item => {
+                html += `
+                    <div class="waste-item" style="border-left-color: ${item.color}">
+                        <div class="waste-icon">${item.icon}</div>
+                        <div class="waste-info">
+                            <div class="waste-type">${item.label}</div>
+                            <div class="waste-date">${item.days_until === 0 ? 'Vandaag' : item.days_until === 1 ? 'Morgen' : 'Over ' + item.days_until + ' dagen'}</div>
+                        </div>
+                        ${getBadge(item.days_until)}
+                    </div>`;
+            });
+
+            html += '</div>';
+        });
+
+        document.getElementById('resultsHeader').textContent =
+            `Ophaaldata voor ${postcode.toUpperCase()} ${huisnummer}${toevoeging ? ' ' + toevoeging : ''}`;
+        document.getElementById('resultsList').innerHTML = html;
+        resultsEl.style.display = 'block';
+
+    } catch (err) {
+        errorEl.textContent = err.message;
+        errorEl.style.display = 'block';
+    } finally {
+        loadingEl.style.display = 'none';
+        btn.disabled = false;
+    }
+});
+
+// Auto-format postcode input
+document.getElementById('postcode').addEventListener('input', function() {
+    this.value = this.value.toUpperCase().replace(/[^0-9A-Z]/g, '');
+});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Flask web app** that shows upcoming afval-ophaaldata op basis van postcode en huisnummer
- Gebruikt de **MijnAfvalwijzer API** (backend van Cure Afvalbeheer) voor ophaalschema's
- Ondersteunt het Cure-gebied: **Eindhoven, Geldrop-Mierlo en Valkenswaard**
- Responsive design met kleurgecodeerde afvaltypes (GFT, Restafval, Papier, PMD, Textiel, etc.)

## Wat is toegevoegd

| Bestand | Beschrijving |
|---------|-------------|
| `app.py` | Flask backend met API-endpoint `/api/ophaaldata` en inputvalidatie |
| `templates/index.html` | Frontend met zoekformulier en overzichtelijke ophaalkalender |
| `requirements.txt` | `flask` en `requests` toegevoegd |

## Hoe te gebruiken

```bash
pip install -r requirements.txt
python app.py
# Open http://localhost:5000
```

Voer een postcode (bijv. `5611AA`) en huisnummer in om de eerstvolgende ophaaldata te zien.

## Test plan

- [ ] Controleer dat de app start met `python app.py`
- [ ] Test met een geldige Eindhoven postcode (bijv. 5611AA, huisnummer 1)
- [ ] Test foutmelding bij ongeldige postcode
- [ ] Test foutmelding bij ontbrekend huisnummer
- [ ] Test op mobiel (responsive layout)

https://claude.ai/code/session_01Tg9xd6RqTGXx4a68XGSY1d